### PR TITLE
パケット作成機能の複数対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b5399f6804fbab912acbd8878ed3532d506b7c951b8f9f164ef90fef39e3f4"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136ef34e18462b17bf39a7826f8f3bbc223341f8e83822beb8b77db9a3d49696"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1695,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1100229e06604150b3becd61a4965d5c70f3be1759544ea7274166f4be41ef43"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168194d373b1e134786274020dae7fc5513d565ea2ebb9bc9ff17ffb69106d4"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2307,11 +2344,12 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustic_rover"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "hidapi",
  "iced",
  "iced_aw",
+ "local-ip-address",
  "serialport",
  "tokio",
  "yaml-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic_rover"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [dependencies]
@@ -11,3 +11,4 @@ tokio = {version = "1", features=["full"]}
 hidapi = "2.6.0"
 serialport = "4.2.0"
 yaml-rust = "0.4"
+local-ip-address = "0.6.1"

--- a/src/rr_core.rs
+++ b/src/rr_core.rs
@@ -5,13 +5,14 @@ mod packet_manager;
 mod utils;
 mod serial_manager;
 mod save_data_manager;
+mod udp_manager;
 
 use controller_manager::DualShock4DriverManager;
 use interface::{AppState,RRMessage, LifeCycle};
 use serial_manager::SerialManager;
 
-use iced::{self, Element};
-use iced::widget::{button, column, combo_box, text};
+use iced;
+use iced::widget::column;
 use iced_aw::Tabs;
 
 
@@ -109,70 +110,34 @@ impl iced::Application for RusticRover {
     }
 
     fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
-        if self.game_controller_manager.state == AppState::NoReady
-        {
-            self.title_view()
-        }
-        else {
-            let home:iced::Element<'_, RRMessage> = column![utils::path_to_image("./rustic_rover.png", 500)].align_items(iced::Alignment::Center).into();
-            let tab = Tabs::new(RRMessage::Cycle)
-            .tab_icon_position(iced_aw::tabs::Position::Bottom)
-            .push(
-                LifeCycle::Home, 
-                iced_aw::TabLabel::Text("Home".to_string()), 
-                home
-            )
-            .push(
-                LifeCycle::ControllerInfo, 
-                self.game_controller_manager.tab_label(), 
-                self.game_controller_manager.view()
-            )
-            .push(
-                LifeCycle::PacketInfo, 
-                self.packet_creator.tab_label(), 
-                self.packet_creator.view()
-            )
-            .push(
-                LifeCycle::SerialInfo, 
-                self.serial_manager.tab_label(), 
-            self.serial_manager.view()
-            )
-            .set_active_tab(&self.life_cycle)
-            .tab_bar_style(iced_aw::style::tab_bar::TabBarStyles::Dark)
-            .tab_bar_position(iced_aw::TabBarPosition::Top)
-            .into();
-
-            tab
-        }
-    }
-}
-
-impl RusticRover {
-    fn title_view(&self)->Element<'_, interface::RRMessage, iced::Theme, iced::Renderer>
-    {
-        let title = text("RusticRover").size(200).horizontal_alignment(iced::alignment::Horizontal::Center);
-        let combo_ = combo_box(
-            &self.game_controller_manager.controller_connection_types_combo_box.all, 
-            "Select Controller Connection Method", 
-            self.game_controller_manager.controller_connection_types_combo_box.selected.as_ref(), 
-            interface::ControllerMessage::TypeSelect);
-
-        let path = "./rustic_rover.png";
-
-        let img = utils::path_to_image(path, 1000);
-
-        let btn = button("Start").on_press(interface::ControllerMessage::ControllerStart).width(iced::Length::Shrink).height(iced::Length::Shrink);
-
-        let err_text = utils::setting_state_logger(self.game_controller_manager.state);
-
-        use iced::widget::container::Container;
-
-        let container:iced::Element<'_, interface::ControllerMessage> = Container::new(
-        column![title, combo_, btn, err_text,img].align_items(iced::alignment::Alignment::Center).padding(10).spacing(50)
+        let home:iced::Element<'_, RRMessage> = column![utils::path_to_image("./rustic_rover.png", 500)].align_items(iced::Alignment::Center).into();
+        let tab = Tabs::new(RRMessage::Cycle)
+        .tab_icon_position(iced_aw::tabs::Position::Bottom)
+        .push(
+            LifeCycle::Home, 
+            iced_aw::TabLabel::Text("Home".to_string()), 
+            home
         )
-        .align_x(iced::alignment::Horizontal::Center)
-        .align_y(iced::alignment::Vertical::Center).into();
+        .push(
+            LifeCycle::ControllerInfo, 
+            self.game_controller_manager.tab_label(), 
+            self.game_controller_manager.view()
+        )
+        .push(
+            LifeCycle::PacketInfo, 
+            self.packet_creator.tab_label(), 
+            self.packet_creator.view()
+        )
+        .push(
+            LifeCycle::SerialInfo, 
+            self.serial_manager.tab_label(), 
+        self.serial_manager.view()
+        )
+        .set_active_tab(&self.life_cycle)
+        .tab_bar_style(iced_aw::style::tab_bar::TabBarStyles::Dark)
+        .tab_bar_position(iced_aw::TabBarPosition::Top)
+        .into();
 
-        container.map(RRMessage::Controller)
+        tab
     }
 }

--- a/src/rr_core/controller_manager.rs
+++ b/src/rr_core/controller_manager.rs
@@ -39,6 +39,19 @@ impl DualShock4DriverManager {
         use iced::widget::container::Container;
         use iced::widget::column;
         match self.controller_num {
+            0=>{
+                let btn = button("Start").on_press(ControllerMessage::ControllerStart).width(iced::Length::Shrink).height(iced::Length::Shrink);
+
+                let err_text = utils::setting_state_logger(self.state);
+
+                let content:iced::Element<'_, ControllerMessage> = Container::new(
+                    column![combo_, btn, err_text].align_items(iced::Alignment::Center)
+                )
+                .align_x(iced::alignment::Horizontal::Center)
+                .align_y(iced::alignment::Vertical::Center).into();
+
+                content.map(RRMessage::Controller)
+            }
             1=>{
                 let con_1 = input_to_controller_view(self.get_value[0]);
                 
@@ -97,16 +110,20 @@ impl DualShock4DriverManager {
                     self.scan_device();
                     if !self.device_list.is_empty()
                     {
+                        self.scan_device();
                         match self.controller_connection_types_combo_box.selected {
                             Some(type_)=>{
                                 self.spawn_driver(type_);
-                                self.controller_num += 1;
                                 self.state = AppState::OK;
                             }
                             None=>{
                                 self.state = AppState::ERROR;
                             }
                         }
+                    }
+                    else {
+                        println!("Not found device");
+                        self.state = AppState::NoReady;
                     }
                 }
             }
@@ -188,6 +205,7 @@ impl DualShock4DriverManager {
         match self.device_list.first()
         {
             Some(dr)=>{
+                self.controller_num += 1;
                 match dr.open_device(&self.api) {
                     Ok(device_)=>{
                         let mut dsdr = DualShock4Driver{device:device_,mode:mode_, rgb:RGB::new()};

--- a/src/rr_core/interface.rs
+++ b/src/rr_core/interface.rs
@@ -27,6 +27,7 @@ pub enum SerialMessage
 #[derive(Debug,Clone)]
 pub enum PacketMessage
 {
+    PacketID(usize),
     FileSelect(String),
     PowerRateX(u16),
     PowerRateY(u16),

--- a/src/rr_core/interface.rs
+++ b/src/rr_core/interface.rs
@@ -11,6 +11,11 @@ pub enum RRMessage
     TabClosed
 }
 
+#[derive(Debug,Clone)]
+pub enum UDPMessage {
+    SpawnUDPDriver
+}
+
 #[derive(Debug, Clone)]
 pub enum SerialMessage
 {

--- a/src/rr_core/packet_manager.rs
+++ b/src/rr_core/packet_manager.rs
@@ -8,17 +8,19 @@ use crate::rr_core::save_data_manager;
 
 pub struct PacketManager
 {
-    pub x_cb:PlusMinus,
-    pub y_cb:PlusMinus,
-    pub ro_cb:PlusMinus,
-    pub m1_cb:PlusMinus,
-    pub m2_cb:PlusMinus,
-    pub packet_:Option<Packet>,
-    pub x_pow_rate:u16,
-    pub y_pow_rate:u16,
-    pub ro_pow_rate:u16,
-    pub m1_pow_rate:u16,
-    pub m2_pow_rate:u16,
+    pub packet_:Vec<Option<Packet>>,
+    pub packet_id:Vec<usize>,
+    pub packet_id_list:ComboBox<usize>,
+    pub x_cb:Vec<PlusMinus>,
+    pub y_cb:Vec<PlusMinus>,
+    pub ro_cb:Vec<PlusMinus>,
+    pub m1_cb:Vec<PlusMinus>,
+    pub m2_cb:Vec<PlusMinus>,
+    pub x_pow_rate:Vec<u16>,
+    pub y_pow_rate:Vec<u16>,
+    pub ro_pow_rate:Vec<u16>,
+    pub m1_pow_rate:Vec<u16>,
+    pub m2_pow_rate:Vec<u16>,
     pub sdm:save_data_manager::SaveDataManager,
     selected_file_name:String,
     pub state:AppState
@@ -37,69 +39,186 @@ impl PacketManager {
     {
         match message {
             PacketMessage::Assign1p(a1p)=>{
-                self.x_cb.plus.selected = Some(a1p)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.x_cb[id].plus.selected = Some(a1p)
+                    }
+                    None=>{
+
+                    }
+                }                
             }
             PacketMessage::Assign1m(a1m)=>{
-                self.x_cb.minus.selected = Some(a1m)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.x_cb[id].minus.selected = Some(a1m)
+                    }
+                    None=>{
+
+                    }
+                }     
             }
             PacketMessage::Assign2p(a2p)=>{
-                self.y_cb.plus.selected = Some(a2p)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.y_cb[id].plus.selected = Some(a2p)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign2m(a2m)=>{
-                self.y_cb.minus.selected = Some(a2m)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.y_cb[id].minus.selected = Some(a2m)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign3p(a3p)=>{
-                self.ro_cb.plus.selected = Some(a3p)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.ro_cb[id].plus.selected = Some(a3p)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign3m(a3m)=>{
-                self.ro_cb.minus.selected = Some(a3m)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.ro_cb[id].minus.selected = Some(a3m)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign4p(a4p)=>{
-                self.m1_cb.plus.selected = Some(a4p)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.m1_cb[id].plus.selected = Some(a4p)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign4m(a4m)=>{
-                self.m1_cb.minus.selected = Some(a4m)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.m1_cb[id].minus.selected = Some(a4m)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign5p(a5p)=>{
-                self.m2_cb.plus.selected = Some(a5p)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.m2_cb[id].plus.selected = Some(a5p)
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::Assign5m(a5m)=>{
-                self.m2_cb.minus.selected = Some(a5m)
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.m2_cb[id].minus.selected = Some(a5m)
+                    }
+                    None=>{
+
+                    }
+                }
             },
             PacketMessage::PowerRateX(x)=>{
-                self.x_pow_rate = x;
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.x_pow_rate[id] = x
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::PowerRateY(y)=>{
-                self.y_pow_rate = y;
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.y_pow_rate[id] = y
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::PowerRateRotation(rotation)=>{
-                self.ro_pow_rate = rotation;
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.ro_pow_rate[id] = rotation
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::PowerRateM1(m1)=>{
-                self.m1_pow_rate = m1;
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.m1_pow_rate[id] = m1
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::PowerRateM2(m2)=>{
-                self.m2_pow_rate = m2;
+                match self.packet_id_list.selected {
+                    Some(id)=>{
+                        self.m2_pow_rate[id] = m2
+                    }
+                    None=>{
+
+                    }
+                }
             }
             PacketMessage::FileSelect(name)=>{
                 self.selected_file_name = name;
 
                 self.sdm.load_from_file(self.selected_file_name.clone());
-                self.x_cb.plus.selected = self.sdm.xp_assign;
-                self.x_cb.minus.selected = self.sdm.xm_assign;
-                self.x_pow_rate = self.sdm.x_rate.unwrap();
-                self.y_cb.plus.selected = self.sdm.yp_assign;
-                self.y_cb.minus.selected = self.sdm.ym_assign;
-                self.y_pow_rate = self.sdm.y_rate.unwrap();
-                self.ro_cb.plus.selected = self.sdm.rop_assign;
-                self.ro_cb.minus.selected = self.sdm.rom_assign;
-                self.ro_pow_rate = self.sdm.ro_rate.unwrap();
-                self.m1_cb.plus.selected = self.sdm.m1p_assign;
-                self.m1_cb.minus.selected = self.sdm.m1m_assign;
-                self.m1_pow_rate = self.sdm.m1_rate.unwrap();
-                self.m2_cb.plus.selected = self.sdm.m2p_assign;
-                self.m2_cb.minus.selected = self.sdm.m2m_assign;
-                self.m2_pow_rate = self.sdm.m2_rate.unwrap();
+
+                match self.packet_id_list.selected
+                {
+                    Some(id)=>{
+                        self.x_cb[id].plus.selected = self.sdm.xp_assign;
+                        self.x_cb[id].minus.selected = self.sdm.xm_assign;
+                        self.x_pow_rate[id] = self.sdm.x_rate.unwrap();
+                        self.y_cb[id].plus.selected = self.sdm.yp_assign;
+                        self.y_cb[id].minus.selected = self.sdm.ym_assign;
+                        self.y_pow_rate[id] = self.sdm.y_rate.unwrap();
+                        self.ro_cb[id].plus.selected = self.sdm.rop_assign;
+                        self.ro_cb[id].minus.selected = self.sdm.rom_assign;
+                        self.ro_pow_rate[id] = self.sdm.ro_rate.unwrap();
+                        self.m1_cb[id].plus.selected = self.sdm.m1p_assign;
+                        self.m1_cb[id].minus.selected = self.sdm.m1m_assign;
+                        self.m1_pow_rate[id] = self.sdm.m1_rate.unwrap();
+                        self.m2_cb[id].plus.selected = self.sdm.m2p_assign;
+                        self.m2_cb[id].minus.selected = self.sdm.m2m_assign;
+                        self.m2_pow_rate[id] = self.sdm.m2_rate.unwrap();
+                    }
+                    None=>{
+
+                    }
+                }
+            }
+            PacketMessage::PacketID(selected_)=>{
+                self.packet_id_list.selected = Some(selected_)
             }
         }
     }
@@ -239,13 +358,23 @@ impl PacketManager {
         let m1_cb_ = PlusMinus::new();
         let m2_cb_ = PlusMinus::new();
 
+        let mut none = Vec::<Option<Packet>>::new();
+        none.push(None);
+
+        let mut packet_id_ = Vec::<usize>::new();
+        packet_id_.push(1);
+
+        let packet_id_list_ = ComboBox::<usize>::new(packet_id_.clone());
+
         PacketManager { 
+            packet_:none,
+            packet_id:packet_id_,
+            packet_id_list:packet_id_list_,
             x_cb: x_cb_, 
             y_cb: y_cb_, 
             ro_cb: ro_cb_, 
             m1_cb: m1_cb_, 
             m2_cb: m2_cb_ , 
-            packet_:None, 
             x_pow_rate:100, 
             y_pow_rate:100, 
             ro_pow_rate:100, 

--- a/src/rr_core/packet_manager.rs
+++ b/src/rr_core/packet_manager.rs
@@ -9,6 +9,7 @@ use crate::rr_core::save_data_manager;
 pub struct PacketManager
 {
     pub packet_:Vec<Option<Packet>>,
+    pub packet_num:usize,
     pub packet_id:Vec<usize>,
     pub packet_id_list:ComboBox<usize>,
     pub x_cb:Vec<PlusMinus>,
@@ -213,7 +214,21 @@ impl PacketManager {
                         self.m2_pow_rate[id] = self.sdm.m2_rate.unwrap();
                     }
                     None=>{
-
+                        self.x_cb[0].plus.selected = self.sdm.xp_assign;
+                        self.x_cb[0].minus.selected = self.sdm.xm_assign;
+                        self.x_pow_rate[0] = self.sdm.x_rate.unwrap();
+                        self.y_cb[0].plus.selected = self.sdm.yp_assign;
+                        self.y_cb[0].minus.selected = self.sdm.ym_assign;
+                        self.y_pow_rate[0] = self.sdm.y_rate.unwrap();
+                        self.ro_cb[0].plus.selected = self.sdm.rop_assign;
+                        self.ro_cb[0].minus.selected = self.sdm.rom_assign;
+                        self.ro_pow_rate[0] = self.sdm.ro_rate.unwrap();
+                        self.m1_cb[0].plus.selected = self.sdm.m1p_assign;
+                        self.m1_cb[0].minus.selected = self.sdm.m1m_assign;
+                        self.m1_pow_rate[0] = self.sdm.m1_rate.unwrap();
+                        self.m2_cb[0].plus.selected = self.sdm.m2p_assign;
+                        self.m2_cb[0].minus.selected = self.sdm.m2m_assign;
+                        self.m2_pow_rate[0] = self.sdm.m2_rate.unwrap();
                     }
                 }
             }
@@ -224,127 +239,279 @@ impl PacketManager {
     }
     pub fn view(&self)->iced::Element<'_, RRMessage>
     {
-        let x_text = text(format!("Select X (Rate : {})", self.x_pow_rate)).size(30);
-        let x_sc = slider(
-            0..=100, 
-            self.x_pow_rate, 
-            PacketMessage::PowerRateX).width(500);
-        let x_title = row![x_text, x_sc];
-        let combo_xp = combo_box(
-            &self.x_cb.plus.all, 
-            "Selecct assign of x plus value", 
-            self.x_cb.plus.selected.as_ref(), 
-            PacketMessage::Assign1p);
-        let combo_xm = combo_box(
-            &self.x_cb.minus.all, 
-            "Selecct assign of x minus value", 
-            self.x_cb.minus.selected.as_ref(), 
-            PacketMessage::Assign1m);
-        let row_x = row![combo_xp, combo_xm].spacing(30);
+        match self.packet_id_list.selected {
+            Some(id)=>{
+                let x_text = text(format!("Select X (Rate : {})", self.x_pow_rate[id])).size(30);
+                let x_sc = slider(
+                    0..=100, 
+                    self.x_pow_rate[id], 
+                    PacketMessage::PowerRateX).width(500);
+                let x_title = row![x_text, x_sc];
+                let combo_xp = combo_box(
+                    &self.x_cb[id].plus.all, 
+                    "Selecct assign of x plus value", 
+                    self.x_cb[id].plus.selected.as_ref(), 
+                    PacketMessage::Assign1p);
+                let combo_xm = combo_box(
+                    &self.x_cb[id].minus.all, 
+                    "Selecct assign of x minus value", 
+                    self.x_cb[id].minus.selected.as_ref(), 
+                    PacketMessage::Assign1m);
+                let row_x = row![combo_xp, combo_xm].spacing(30);
 
-        let y_text = text(format!("Select Y (Rate : {})", self.y_pow_rate)).size(30);
-        let y_sc = slider(
-            0..=100, 
-            self.y_pow_rate, 
-            PacketMessage::PowerRateY).width(500);
-        let y_title = row![y_text, y_sc];
-        let combo_yp = combo_box(
-            &self.y_cb.plus.all, 
-            "Selecct assign of y plus value", 
-            self.y_cb.plus.selected.as_ref(), 
-            PacketMessage::Assign2p);
-        let combo_ym = combo_box(
-            &self.y_cb.minus.all, 
-            "Selecct assign of y minus value", 
-            self.y_cb.minus.selected.as_ref(), 
-            PacketMessage::Assign2m);
-        let row_y = row![combo_yp, combo_ym].spacing(30);
+                let y_text = text(format!("Select Y (Rate : {})", self.y_pow_rate[id])).size(30);
+                let y_sc = slider(
+                    0..=100, 
+                    self.y_pow_rate[id], 
+                    PacketMessage::PowerRateY).width(500);
+                let y_title = row![y_text, y_sc];
+                let combo_yp = combo_box(
+                    &self.y_cb[id].plus.all, 
+                    "Selecct assign of y plus value", 
+                    self.y_cb[id].plus.selected.as_ref(), 
+                    PacketMessage::Assign2p);
+                let combo_ym = combo_box(
+                    &self.y_cb[id].minus.all, 
+                    "Selecct assign of y minus value", 
+                    self.y_cb[id].minus.selected.as_ref(), 
+                    PacketMessage::Assign2m);
+                let row_y = row![combo_yp, combo_ym].spacing(30);
 
-        let ro_text = text(format!("Select Rotation (Rate : {})", self.ro_pow_rate)).size(30);
-        let ro_sc = slider(
-            0..=100, 
-            self.ro_pow_rate, 
-            PacketMessage::PowerRateRotation).width(500);
-        let ro_title = row![ro_text, ro_sc];
+                let ro_text = text(format!("Select Rotation (Rate : {})", self.ro_pow_rate[id])).size(30);
+                let ro_sc = slider(
+                    0..=100, 
+                    self.ro_pow_rate[id], 
+                    PacketMessage::PowerRateRotation).width(500);
+                let ro_title = row![ro_text, ro_sc];
 
-        let combo_rop = combo_box(
-            &self.ro_cb.plus.all, 
-            "Selecct assign of rotation plus value", 
-            self.ro_cb.plus.selected.as_ref(), 
-            PacketMessage::Assign3p);
-        let combo_rom = combo_box(
-            &self.ro_cb.minus.all, 
-            "Selecct assign of rotation minus value", 
-            self.ro_cb.minus.selected.as_ref(), 
-            PacketMessage::Assign3m);
-        let row_ro = row![combo_rop, combo_rom].spacing(30);
+                let combo_rop = combo_box(
+                    &self.ro_cb[id].plus.all, 
+                    "Selecct assign of rotation plus value", 
+                    self.ro_cb[id].plus.selected.as_ref(), 
+                    PacketMessage::Assign3p);
+                let combo_rom = combo_box(
+                    &self.ro_cb[id].minus.all, 
+                    "Selecct assign of rotation minus value", 
+                    self.ro_cb[id].minus.selected.as_ref(), 
+                    PacketMessage::Assign3m);
+                let row_ro = row![combo_rop, combo_rom].spacing(30);
 
-        let m1_text = text(format!("Select Machine1 (Rate : {})", self.m1_pow_rate)).size(30);
-        let m1_sc = slider(
-            0..=100, 
-            self.m1_pow_rate, 
-            PacketMessage::PowerRateM1).width(500);
-        let m1_title = row![m1_text, m1_sc];
-        let combo_m1p = combo_box(
-            &self.m1_cb.plus.all, 
-            "Selecct assign of machine1 plus value", 
-            self.m1_cb.plus.selected.as_ref(), 
-            PacketMessage::Assign4p);
-        let combo_m1m = combo_box(
-            &self.m1_cb.minus.all, 
-            "Selecct assign of machine1 minus value", 
-            self.m1_cb.minus.selected.as_ref(), 
-            PacketMessage::Assign4m);
-        let row_m1 = row![combo_m1p, combo_m1m].spacing(30);
+                let m1_text = text(format!("Select Machine1 (Rate : {})", self.m1_pow_rate[id])).size(30);
+                let m1_sc = slider(
+                    0..=100, 
+                    self.m1_pow_rate[id], 
+                    PacketMessage::PowerRateM1).width(500);
+                let m1_title = row![m1_text, m1_sc];
+                let combo_m1p = combo_box(
+                    &self.m1_cb[id].plus.all, 
+                    "Selecct assign of machine1 plus value", 
+                    self.m1_cb[id].plus.selected.as_ref(), 
+                    PacketMessage::Assign4p);
+                let combo_m1m = combo_box(
+                    &self.m1_cb[id].minus.all, 
+                    "Selecct assign of machine1 minus value", 
+                    self.m1_cb[id].minus.selected.as_ref(), 
+                    PacketMessage::Assign4m);
+                let row_m1 = row![combo_m1p, combo_m1m].spacing(30);
 
-        let m2_text = text(format!("Select Machine2 (Rate : {})", self.m2_pow_rate)).size(30);
-        let m2_sc = slider(
-            0..=100, 
-            self.m2_pow_rate, 
-            PacketMessage::PowerRateM2).width(500);
-        let m2_title = row![m2_text, m2_sc];
-        let combo_m2p = combo_box(
-            &self.m2_cb.plus.all, 
-            "Selecct assign of machine2 plus value", 
-            self.m2_cb.plus.selected.as_ref(), 
-            PacketMessage::Assign5p);
-        let combo_m2m = combo_box(
-            &self.m2_cb.minus.all, 
-            "Selecct assign of machine2 minus value", 
-            self.m2_cb.minus.selected.as_ref(), 
-            PacketMessage::Assign5m);
-        let row_m2 = row![combo_m2p, combo_m2m].spacing(30);
+                let m2_text = text(format!("Select Machine2 (Rate : {})", self.m2_pow_rate[id])).size(30);
+                let m2_sc = slider(
+                    0..=100, 
+                    self.m2_pow_rate[id], 
+                    PacketMessage::PowerRateM2).width(500);
+                let m2_title = row![m2_text, m2_sc];
+                let combo_m2p = combo_box(
+                    &self.m2_cb[id].plus.all, 
+                    "Selecct assign of machine2 plus value", 
+                    self.m2_cb[id].plus.selected.as_ref(), 
+                    PacketMessage::Assign5p);
+                let combo_m2m = combo_box(
+                    &self.m2_cb[id].minus.all, 
+                    "Selecct assign of machine2 minus value", 
+                    self.m2_cb[id].minus.selected.as_ref(), 
+                    PacketMessage::Assign5m);
+                let row_m2 = row![combo_m2p, combo_m2m].spacing(30);
 
-        let p_text = match self.packet_ {
-            Some(p)=>{
-                text(format!("[x:{:3},y:{:3},ro:{:3},m1:{:3},m2:{:3}]", p.x, p.y, p.ro, p.m1, p.m2)).size(50)
+                let p_text = match self.packet_[id] {
+                    Some(p)=>{
+                        text(format!("[x:{:3},y:{:3},ro:{:3},m1:{:3},m2:{:3}]", p.x, p.y, p.ro, p.m1, p.m2)).size(50)
+                    }
+                    None=>{
+                        text("Failed to Create Packet").size(50)
+                    }
+                };
+
+                let id_title = text("Select Packet ID").size(30);
+                let combo_id = combo_box(
+                    &self.packet_id_list.all, 
+                    "Select Packet ID", 
+                    self.packet_id_list.selected.as_ref(), 
+                    PacketMessage::PacketID
+                );
+
+                let sdm_menu = self.sdm.menu_view(self.selected_file_name.clone());
+
+                use iced::widget::container::Container;
+                let container:iced::Element<'_, PacketMessage> = Container::new(
+                    column![
+                            x_title,
+                            row_x,
+                            y_title,
+                            row_y,
+                            ro_title,
+                            row_ro,
+                            m1_title,
+                            row_m1,
+                            m2_title,
+                            row_m2,
+                            p_text,
+                            sdm_menu,
+                            id_title,
+                            combo_id
+                    ].align_items(iced::Alignment::Center)
+                )
+                .align_x(iced::alignment::Horizontal::Center)
+                .align_y(iced::alignment::Vertical::Center).into();
+
+                container.map(RRMessage::Packet)
             }
             None=>{
-                text("Failed to Create Packet").size(50)
+                let x_text = text(format!("Select X (Rate : {})", self.x_pow_rate[0])).size(30);
+                let x_sc = slider(
+                    0..=100, 
+                    self.x_pow_rate[0], 
+                    PacketMessage::PowerRateX).width(500);
+                let x_title = row![x_text, x_sc];
+                let combo_xp = combo_box(
+                    &self.x_cb[0].plus.all, 
+                    "Selecct assign of x plus value", 
+                    self.x_cb[0].plus.selected.as_ref(), 
+                    PacketMessage::Assign1p);
+                let combo_xm = combo_box(
+                    &self.x_cb[0].minus.all, 
+                    "Selecct assign of x minus value", 
+                    self.x_cb[0].minus.selected.as_ref(), 
+                    PacketMessage::Assign1m);
+                let row_x = row![combo_xp, combo_xm].spacing(30);
+
+                let y_text = text(format!("Select Y (Rate : {})", self.y_pow_rate[0])).size(30);
+                let y_sc = slider(
+                    0..=100, 
+                    self.y_pow_rate[0], 
+                    PacketMessage::PowerRateY).width(500);
+                let y_title = row![y_text, y_sc];
+                let combo_yp = combo_box(
+                    &self.y_cb[0].plus.all, 
+                    "Selecct assign of y plus value", 
+                    self.y_cb[0].plus.selected.as_ref(), 
+                    PacketMessage::Assign2p);
+                let combo_ym = combo_box(
+                    &self.y_cb[0].minus.all, 
+                    "Selecct assign of y minus value", 
+                    self.y_cb[0].minus.selected.as_ref(), 
+                    PacketMessage::Assign2m);
+                let row_y = row![combo_yp, combo_ym].spacing(30);
+
+                let ro_text = text(format!("Select Rotation (Rate : {})", self.ro_pow_rate[0])).size(30);
+                let ro_sc = slider(
+                    0..=100, 
+                    self.ro_pow_rate[0], 
+                    PacketMessage::PowerRateRotation).width(500);
+                let ro_title = row![ro_text, ro_sc];
+
+                let combo_rop = combo_box(
+                    &self.ro_cb[0].plus.all, 
+                    "Selecct assign of rotation plus value", 
+                    self.ro_cb[0].plus.selected.as_ref(), 
+                    PacketMessage::Assign3p);
+                let combo_rom = combo_box(
+                    &self.ro_cb[0].minus.all, 
+                    "Selecct assign of rotation minus value", 
+                    self.ro_cb[0].minus.selected.as_ref(), 
+                    PacketMessage::Assign3m);
+                let row_ro = row![combo_rop, combo_rom].spacing(30);
+
+                let m1_text = text(format!("Select Machine1 (Rate : {})", self.m1_pow_rate[0])).size(30);
+                let m1_sc = slider(
+                    0..=100, 
+                    self.m1_pow_rate[0], 
+                    PacketMessage::PowerRateM1).width(500);
+                let m1_title = row![m1_text, m1_sc];
+                let combo_m1p = combo_box(
+                    &self.m1_cb[0].plus.all, 
+                    "Selecct assign of machine1 plus value", 
+                    self.m1_cb[0].plus.selected.as_ref(), 
+                    PacketMessage::Assign4p);
+                let combo_m1m = combo_box(
+                    &self.m1_cb[0].minus.all, 
+                    "Selecct assign of machine1 minus value", 
+                    self.m1_cb[0].minus.selected.as_ref(), 
+                    PacketMessage::Assign4m);
+                let row_m1 = row![combo_m1p, combo_m1m].spacing(30);
+
+                let m2_text = text(format!("Select Machine2 (Rate : {})", self.m2_pow_rate[0])).size(30);
+                let m2_sc = slider(
+                    0..=100, 
+                    self.m2_pow_rate[0], 
+                    PacketMessage::PowerRateM2).width(500);
+                let m2_title = row![m2_text, m2_sc];
+                let combo_m2p = combo_box(
+                    &self.m2_cb[0].plus.all, 
+                    "Selecct assign of machine2 plus value", 
+                    self.m2_cb[0].plus.selected.as_ref(), 
+                    PacketMessage::Assign5p);
+                let combo_m2m = combo_box(
+                    &self.m2_cb[0].minus.all, 
+                    "Selecct assign of machine2 minus value", 
+                    self.m2_cb[0].minus.selected.as_ref(), 
+                    PacketMessage::Assign5m);
+                let row_m2 = row![combo_m2p, combo_m2m].spacing(30);
+
+                let p_text = match self.packet_[0] {
+                    Some(p)=>{
+                        text(format!("[x:{:3},y:{:3},ro:{:3},m1:{:3},m2:{:3}]", p.x, p.y, p.ro, p.m1, p.m2)).size(50)
+                    }
+                    None=>{
+                        text("Failed to Create Packet").size(50)
+                    }
+                };
+
+                let sdm_menu = self.sdm.menu_view(self.selected_file_name.clone());
+
+                let id_title = text("Select Packet ID").size(30);
+                let combo_id = combo_box(
+                    &self.packet_id_list.all, 
+                    "Select Packet ID", 
+                    self.packet_id_list.selected.as_ref(), 
+                    PacketMessage::PacketID
+                );
+
+                use iced::widget::container::Container;
+                let container:iced::Element<'_, PacketMessage> = Container::new(
+                    column![
+                            x_title,
+                            row_x,
+                            y_title,
+                            row_y,
+                            ro_title,
+                            row_ro,
+                            m1_title,
+                            row_m1,
+                            m2_title,
+                            row_m2,
+                            p_text,
+                            sdm_menu,
+                            id_title,
+                            combo_id
+                    ].align_items(iced::Alignment::Center)
+                )
+                .align_x(iced::alignment::Horizontal::Center)
+                .align_y(iced::alignment::Vertical::Center).into();
+
+                container.map(RRMessage::Packet)
             }
-        };
-
-        use iced::widget::container::Container;
-        let container:iced::Element<'_, PacketMessage> = Container::new(
-            column![
-                    x_title,
-                    row_x,
-                    y_title,
-                    row_y,
-                    ro_title,
-                    row_ro,
-                    m1_title,
-                    row_m1,
-                    m2_title,
-                    row_m2,
-                    p_text,
-                    self.sdm.menu_view(self.selected_file_name.clone())
-            ].align_items(iced::Alignment::Center)
-        )
-        .align_x(iced::alignment::Horizontal::Center)
-        .align_y(iced::alignment::Vertical::Center).into();
-
-        container.map(RRMessage::Packet)
+        }
+        
     }
 }
 
@@ -352,22 +519,39 @@ impl PacketManager {
 impl PacketManager {
     pub fn new()->PacketManager
     {
-        let x_cb_ = PlusMinus::new();
-        let y_cb_ = PlusMinus::new();
-        let ro_cb_ = PlusMinus::new();
-        let m1_cb_ = PlusMinus::new();
-        let m2_cb_ = PlusMinus::new();
+        let mut x_cb_ = Vec::<PlusMinus>::new();
+        x_cb_.push(PlusMinus::new());
+        let mut y_cb_ = Vec::<PlusMinus>::new();
+        y_cb_.push(PlusMinus::new());
+        let mut ro_cb_ = Vec::<PlusMinus>::new();
+        ro_cb_.push(PlusMinus::new());
+        let mut m1_cb_ = Vec::<PlusMinus>::new();
+        m1_cb_.push(PlusMinus::new());
+        let mut m2_cb_ = Vec::<PlusMinus>::new();
+        m2_cb_.push(PlusMinus::new());
+
+        let mut x_rate = Vec::<u16>::new();
+        x_rate.push(100);
+        let mut y_rate = Vec::<u16>::new();
+        y_rate.push(100);
+        let mut ro_rate = Vec::<u16>::new();
+        ro_rate.push(100);
+        let mut m1_rate = Vec::<u16>::new();
+        m1_rate.push(100);
+        let mut m2_rate = Vec::<u16>::new();
+        m2_rate.push(100);
 
         let mut none = Vec::<Option<Packet>>::new();
         none.push(None);
 
         let mut packet_id_ = Vec::<usize>::new();
-        packet_id_.push(1);
+        packet_id_.push(0);
 
         let packet_id_list_ = ComboBox::<usize>::new(packet_id_.clone());
 
         PacketManager { 
             packet_:none,
+            packet_num:1,
             packet_id:packet_id_,
             packet_id_list:packet_id_list_,
             x_cb: x_cb_, 
@@ -375,61 +559,81 @@ impl PacketManager {
             ro_cb: ro_cb_, 
             m1_cb: m1_cb_, 
             m2_cb: m2_cb_ , 
-            x_pow_rate:100, 
-            y_pow_rate:100, 
-            ro_pow_rate:100, 
-            m1_pow_rate:100, 
-            m2_pow_rate:100,
+            x_pow_rate:x_rate, 
+            y_pow_rate:y_rate, 
+            ro_pow_rate:ro_rate, 
+            m1_pow_rate:m1_rate, 
+            m2_pow_rate:m2_rate,
             sdm:save_data_manager::SaveDataManager::new(),
             selected_file_name:String::new(),
             state:AppState::NoReady,
         }
     }
 
-    pub fn create_packet(&mut self, controller_input:DualShock4)
+    pub fn create_packet(&mut self, controller_input:DualShock4, id:usize)
     {
-        match assign_to_controller(self.x_cb.clone(), controller_input)
-        {
-            Some(x_)=>{
-                match assign_to_controller(self.y_cb.clone(), controller_input) {
-                    Some(y_)=>{
-                        match assign_to_controller(self.ro_cb.clone(), controller_input) {
-                            Some(ro_)=>{
-                                match assign_to_controller(self.m1_cb.clone(), controller_input) {
-                                    Some(m1_)=>{
-                                        match assign_to_controller(self.m2_cb.clone(), controller_input) {
-                                            Some(m2_)=>{
-                                                self.packet_ = Some(Packet {
-                                                     x: (x_  *self.x_pow_rate as f32) as i32, 
-                                                     y: (y_  *self.y_pow_rate as f32) as i32, 
-                                                     ro: (ro_  *self.ro_pow_rate as f32) as i32, 
-                                                     m1: (m1_  *self.m1_pow_rate as f32) as i32, 
-                                                     m2: (m2_  *self.m2_pow_rate as f32) as i32})
+                match assign_to_controller(self.x_cb[id].clone(), controller_input)
+                {
+                    Some(x_)=>{
+                        match assign_to_controller(self.y_cb[id].clone(), controller_input) {
+                            Some(y_)=>{
+                                match assign_to_controller(self.ro_cb[id].clone(), controller_input) {
+                                    Some(ro_)=>{
+                                        match assign_to_controller(self.m1_cb[id].clone(), controller_input) {
+                                            Some(m1_)=>{
+                                                match assign_to_controller(self.m2_cb[id].clone(), controller_input) {
+                                                    Some(m2_)=>{
+                                                        self.packet_[id] = Some(Packet {
+                                                            x: (x_  *self.x_pow_rate[id] as f32) as i32, 
+                                                            y: (y_  *self.y_pow_rate[id] as f32) as i32, 
+                                                            ro: (ro_  *self.ro_pow_rate[id] as f32) as i32, 
+                                                            m1: (m1_  *self.m1_pow_rate[id] as f32) as i32, 
+                                                            m2: (m2_  *self.m2_pow_rate[id] as f32) as i32})
+                                                    }
+                                                    None=>{
+                                                        self.packet_[id] =None
+                                                    }
+                                                }
                                             }
                                             None=>{
-                                                self.packet_ =None
+                                                self.packet_[id] =None
                                             }
                                         }
                                     }
                                     None=>{
-                                        self.packet_ =None
+                                        self.packet_[id] =None
                                     }
                                 }
                             }
                             None=>{
-                                self.packet_ =None
+                                self.packet_[id] =None
                             }
                         }
                     }
                     None=>{
-                        self.packet_ =None
+                        self.packet_[id] =None
                     }
-                }
-            }
-            None=>{
-                self.packet_ =None
-            }
         }
+    }
+
+    pub fn new_set(&mut self)
+    {
+        self.x_cb.push(PlusMinus::new());
+        self.y_cb.push(PlusMinus::new());
+        self.ro_cb.push(PlusMinus::new());
+        self.m1_cb.push(PlusMinus::new());
+        self.m2_cb.push(PlusMinus::new());
+        self.x_pow_rate.push(100);
+        self.y_pow_rate.push(100);
+        self.ro_pow_rate.push(100);
+        self.m1_pow_rate.push(100);
+        self.m2_pow_rate.push(100);
+
+        self.packet_.push(None);
+        self.packet_id.push(1);
+        self.packet_id_list = ComboBox::new(self.packet_id.clone());
+
+        self.packet_num += 1;
     }
 }
 

--- a/src/rr_core/thread_connection.rs
+++ b/src/rr_core/thread_connection.rs
@@ -1,6 +1,9 @@
 use std::cell::RefCell;
 use tokio::sync::mpsc;
 use std::sync::mpsc::{channel, Sender, Receiver};
+
+pub type Publisher<T> = Sender<T>;
+pub type Subscriber<T> = Receiver<T>;
 pub struct AsyncThreadConnector<T>
 {
     pub publisher:RefCell<Option<mpsc::UnboundedSender<T>>>,
@@ -18,8 +21,8 @@ impl<T> AsyncThreadConnector<T> {
 
 pub struct ThreadConnector<T>
 {
-    pub publisher:Sender<T>,
-    pub subscriber:Receiver<T>
+    pub publisher:Publisher<T>,
+    pub subscriber:Subscriber<T>
 }
 
 impl<T> ThreadConnector<T> {

--- a/src/rr_core/udp_manager.rs
+++ b/src/rr_core/udp_manager.rs
@@ -1,0 +1,107 @@
+extern crate local_ip_address as local;
+use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+use iced_aw::TabLabel;
+
+use crate::rr_core::thread_connection::ThreadConnector;
+use crate::rr_core::interface::{Packet, UDPMessage};
+
+pub struct UDPManager
+{
+    pub local_addr:IpAddr,
+    pub connector:Vec<ThreadConnector<Packet>>,
+    pub socket_num:usize,
+    pub dest_addr:Ipv4Addr
+}
+
+impl UDPManager {
+    fn title(&self)->String
+    {
+        String::from("UDP Manager")
+    }
+    fn tab_label(&self)->TabLabel
+    {
+        TabLabel::Text(self.title())
+    }
+    pub fn update(&mut self, message:UDPMessage)
+    {
+        match message {
+            UDPMessage::SpawnUDPDriver=>{
+                
+            }
+        }
+    }
+}
+
+impl UDPManager {
+    pub fn new()->UDPManager
+    {
+        let new_sock_address = local::local_ip().unwrap();
+        if let IpAddr::V4(ipv4) = new_sock_address{
+            let octets = ipv4.octets();
+            UDPManager { 
+                local_addr: new_sock_address,
+                connector: Vec::<ThreadConnector<Packet>>::new(),
+                socket_num:0,
+                dest_addr:Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3])
+            }
+        }
+        else {
+            UDPManager { 
+                local_addr: new_sock_address,
+                connector: Vec::<ThreadConnector<Packet>>::new(),
+                socket_num:0,
+                dest_addr:Ipv4Addr::new(0, 0, 0, 0)
+            }
+        }
+        
+    }
+    pub fn spawn_driver(&mut self)
+    {
+        let searcher_addr = format!("{}:{}", self.local_addr.to_string(), 64250+self.socket_num);
+        
+
+        let sock = UdpSocket::bind(searcher_addr).unwrap();
+
+        let new_connector = ThreadConnector::<Packet>::new();
+        self.connector.push(new_connector);
+
+        let use_connector = ThreadConnector::<Packet>::new();
+        self.connector[self.socket_num].publisher = use_connector.publisher.clone();
+        
+
+        self.socket_num += 1;
+
+
+        std::thread::spawn(move ||{
+            let mut ab = "a";
+            loop
+            {
+                let send_packet = use_connector.subscriber.recv().unwrap();
+
+                if ab == "a"
+                {
+                    ab = "b";
+                }
+                else {
+                    ab = "a"
+                }
+
+                let write_buf = format!("{}{},{},{},{},{}e", ab,
+                        send_packet.x/10 as i32+10,
+                        send_packet.y/10 as i32+10,
+                        send_packet.ro/10 as i32+10,
+                        send_packet.m1/10 as i32+10,
+                        send_packet.m2/10 as i32+10);
+                match sock.send(write_buf.as_bytes()) {
+                    Ok(_size)=>{
+
+                    }
+                    Err(_e)=>{
+
+                    }
+                }
+
+            }
+        });
+    }
+}


### PR DESCRIPTION
プレイヤーの入力の数だけパケットの種類を分けれるようにした。
これで各ロボットごとに別々の割り当てのコントローラーをひとつのソフトウェアで実現できる。

UDPDriverも機能はしないけど追加だけされてます。

タイトル画面がいらないかなと思ったので消した。